### PR TITLE
alterações valores de ataque

### DIFF
--- a/src/pages/PokemonBattlePage/PokemonBattlePage.js
+++ b/src/pages/PokemonBattlePage/PokemonBattlePage.js
@@ -14,7 +14,7 @@ import {
 import axios from "axios";
 import { BASE_URL } from "../../constants/url";
 import { goToPokemonDetailsPage, goToHomePage } from "../../routes/Coordinator";
-import { useAttackStrenght } from "./attackStrenght";
+import { useAttackStrength } from "./useAttackStrength";
 
 const PokemonBattlePage = () => {
   const history = useHistory();
@@ -26,12 +26,8 @@ const PokemonBattlePage = () => {
   const [pokemonDamage, setPokemonDamage] = useState();
   const [rivalHp, setRivalHp] = useState();
   const [pokemonHp, setPokemonHp] = useState();
+  const { pokemonStrength, rivalStrength } = useAttackStrength(pokemon, rival)
 
-  console.log(pokemon)
-  console.log(rival)
-  console.log("pokemonStrenght", pokemonStrenght)
-  console.log("rivalStrenght", rivalStrenght)
-  console.log("rivalDamage", rivalDamage)
   const sortRival = () => {
     const index = randomIndex();
     let pokemonRival = pokemons[index];
@@ -166,7 +162,7 @@ const PokemonBattlePage = () => {
       indexDefense = 0;
     }
     const attack = value * 2
-    const damage = Math.floor((attack - rivalDefense[indexDefense]) / 2)
+    const damage = Math.floor((attack - rivalDefense[indexDefense]) / rivalStrength)
     if (damage > 0) {
       setRivalDamage(damage);
     } else {
@@ -179,7 +175,7 @@ const PokemonBattlePage = () => {
     const pokemonDefense = [pokemon.stats[2].base_stat, pokemon.stats[4].base_stat]
     const randomIndexBattle = Math.floor(Math.random(0, 2));
     const attack = (rivalAttackArray[randomIndexBattle] * 2)
-    const damage = Math.floor((attack - pokemonDefense[randomIndexBattle]) / 2)
+    const damage = Math.floor((attack - pokemonDefense[randomIndexBattle]) / pokemonStrength)
     if (damage > 0) {
       setPokemonDamage(damage);
     } else {

--- a/src/pages/PokemonBattlePage/useAttackStrength.js
+++ b/src/pages/PokemonBattlePage/useAttackStrength.js
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react"
+
+export const useAttackStrength = (pokemon, rival) => {
+    const [pokemonStrength, setPokemonStrength] = useState(3)
+    const [rivalStrength, setRivalStrength] = useState(3)
+    const [pokemonType, setPokemonType] = useState([])
+    const [rivalType, setRivalType] = useState([])
+
+    useEffect(() => {
+
+        if (pokemon && pokemon.types) {
+            const types = []
+            pokemon.types.map((type) => {
+                console.log("tipo: ", type.type.name)
+                types.push(type.type.name)
+                console.log("tipo: ", types)
+            })
+            setPokemonType(types)
+        }
+        if (rival && rival.types) {
+            const types = []
+            rival.types.forEach((type) => {
+                types.push(type.type.name)
+            })
+            setRivalType(types)
+        }
+    }, [rival])
+
+
+    useEffect(() => {
+        if ((pokemonType.includes("grass") && rivalType.includes("fire")) ||
+            (pokemonType.includes("fire") && rivalType.includes("water")) ||
+            (pokemonType.includes("water") && rivalType.includes("grass")) ||
+            (pokemonType.includes("water") && rivalType.includes("electric")) ||
+            (pokemonType.includes("electric") && rivalType.includes("grass"))
+        ) {
+            setRivalStrength(4)
+            setPokemonStrength(2)
+        } else if ((rivalType.includes("grass") && pokemonType.includes("fire")) ||
+            (rivalType.includes("fire") && pokemonType.includes("water")) ||
+            (rivalType.includes("water") && pokemonType.includes("grass")) ||
+            (rivalType.includes("water") && pokemonType.includes("electric")) ||
+            (rivalType.includes("electric") && pokemonType.includes("grass"))
+        ) {
+            setPokemonStrength(4)
+            setRivalStrength(2)
+        } else {
+            setPokemonStrength(3)
+            setRivalStrength(3)
+        }
+    }, [rivalType, pokemonType])
+
+
+    return { pokemonStrength, rivalStrength }
+}


### PR DESCRIPTION
mudança no valor do ataque:
quando os pokémons  dos 4 tipos "principais" (planta, terra, fogo e elétrico) estão batalhando com outro de um tipo em que sejam mais fortes ou mais fracos, a pontuação do dano que sofrem/causam, muda .